### PR TITLE
Quote properties consistently

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
 	"trailingComma": "none",
 	"printWidth": 100,
 	"pluginSearchDirs": ["."],
+	"quoteProps": "consistent",
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -6,17 +6,17 @@ module.exports = {
 			colors: {
 				'pine-glade': '#C7D19E',
 				'ship-cove': '#6E91B9',
-				mirage: {
+				'mirage': {
 					DEFAULT: '#191F2D',
 					darker: '#151B29'
 				},
 				'cadet-blue': '#A0A8C3',
-				comet: {
+				'comet': {
 					DEFAULT: '#636985',
 					darker: '#434965'
 				},
 				'orange-red-crayola': '#FF5A5F',
-				cultured: '#F5F5F5',
+				'cultured': '#F5F5F5',
 				'tea-green': '#C4D6B0'
 			},
 			fontFamily: {


### PR DESCRIPTION
Resolves #7
- Update `.prettierrc` to use quotes if any sibling property requires quotes